### PR TITLE
Generalized write_sra_table

### DIFF
--- a/R/biosamples.R
+++ b/R/biosamples.R
@@ -82,19 +82,7 @@ build_biosamples_from_template <- function(package_name,
 #' @export
 #' @describeIn write_biosamples Write SRA BioSample attributes to disk
 write_biosamples <- function(data, ...) {
-  s <- attributes(data)$submission
-  if (! is.null(s)) {
-    dp <- s
-    if (! dir.exists(dp)) {
-      dir.create(dp)
-    }
-    fn <- paste0(s, "_biosamples.tsv")
-  } else {
-    dp <- "."
-    fn <- "biosamples.tsv"
-  }
-  fp <- file.path(dp, fn)
-  write_sra_table(data, fp, ...)
+  write_sra_table(data, fp_suffix = "biosamples", ...)
 }
 
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -3,19 +3,7 @@
 
 #' @describeIn write_biosamples Write SRA library metadata to disk
 write_metadata <- function(data, ...) {
-  s <- attributes(data)$submission
-  if (! is.null(s)) {
-    dp <- s
-    if (! dir.exists(dp)) {
-      dir.create(dp)
-    }
-    fn <- paste0(s, "_metadata.tsv")
-  } else {
-    dp <- "."
-    fn <- "metadata.tsv"
-  }
-  fp <- file.path(dp, fn)
-  write_sra_table(data, fp, ...)
+  write_sra_table(data, fp_suffix = "metadata", ...)
 }
 
 #' Create blank metadata

--- a/R/tables.R
+++ b/R/tables.R
@@ -9,15 +9,37 @@
 #' in TSV format.
 #'
 #' @param data data frame of SRA metadata
-#' @param fp file path to save text
+#' @param fp file path to save text.  If \code{NULL}, will be determined by the
+#'   \code{submission} attribute on \code{data}, if present, and
+#'   \code{fp_suffix}, if given, relative to the current working directory.
+#' @param fp_suffix A filename suffix to use when constructing output file path
+#'   if \code{fp} is not given.
 #' @param overwrite should existing files be replaced?  If \code{FALSE}
 #'   (default), an existing file throws an error.  If \code{TRUE}, an existing
 #'   file is replaced without any prompting.
 #' @param ... additional arguments for \code{utils::write.table}
 #'
+#' @return The file path written to, for \code{write_sra_table}, or a data frame
+#'   read, for \code{read_sra_table}.
+#'
 #' @export
 #' @describeIn write_sra_table Write SRA metadata to disk
-write_sra_table <- function(data, fp, overwrite=FALSE, ...) {
+write_sra_table <- function(data, fp=NULL, fp_suffix="data", overwrite=FALSE, ...) {
+  if (is.null(fp)) {
+    # Automatically determine output file path
+    s <- attributes(data)$submission
+    if (! is.null(s)) {
+      dp <- s
+      if (! dir.exists(dp)) {
+        dir.create(dp)
+      }
+      fn <- paste0(s, "_", fp_suffix, ".tsv")
+    } else {
+      dp <- "."
+      fn <- paste0(fp_suffix, ".tsv")
+    }
+    fp <- file.path(dp, fn)
+  }
   # empty strings are allowed in the BioProject Accession column for the
   # Biosamples spreadsheet, but not "not applicable".
   if ("bioproject_accession" %in% colnames(data)) {
@@ -39,6 +61,7 @@ write_sra_table <- function(data, fp, overwrite=FALSE, ...) {
                      na = "not applicable",
                      row.names = FALSE,
                      ...)
+  return(fp)
 }
 
 #' @describeIn write_sra_table Read SRA metadata from disk

--- a/man/write_sra_table.Rd
+++ b/man/write_sra_table.Rd
@@ -5,20 +5,30 @@
 \alias{read_sra_table}
 \title{Read and write SRA metadata to disk}
 \usage{
-write_sra_table(data, fp, overwrite = FALSE, ...)
+write_sra_table(data, fp = NULL, fp_suffix = "data",
+  overwrite = FALSE, ...)
 
 read_sra_table(fp, ...)
 }
 \arguments{
 \item{data}{data frame of SRA metadata}
 
-\item{fp}{file path to save text}
+\item{fp}{file path to save text.  If \code{NULL}, will be determined by the
+\code{submission} attribute on \code{data}, if present, and
+\code{fp_suffix}, if given, relative to the current working directory.}
+
+\item{fp_suffix}{A filename suffix to use when constructing output file path
+if \code{fp} is not given.}
 
 \item{overwrite}{should existing files be replaced?  If \code{FALSE}
 (default), an existing file throws an error.  If \code{TRUE}, an existing
 file is replaced without any prompting.}
 
 \item{...}{additional arguments for \code{utils::write.table}}
+}
+\value{
+The file path written to, for \code{write_sra_table}, or a data frame
+  read, for \code{read_sra_table}.
 }
 \description{
 These functions read and write to/from a data frame of SRA metadata (a

--- a/tests/testthat/test_tables.R
+++ b/tests/testthat/test_tables.R
@@ -26,13 +26,7 @@ test_that("read_sra_table reads a Run Info table", {
 
 # write_sra_table ---------------------------------------------------------
 
-
-test_that("write_sra_table writes SRA fields", {
-  # Test write_sra_table alongside read_sra_table by ensuring they match.
-  data <- setup_sra_table()
-  fp <- tempfile()
-  write_sra_table(data, fp)
-  expect_true(file.exists(fp))
+check_sra_table_written <- function(data, fp) {
   # Rownames will be sample names
   rownames(data) <- data$sample_name
   # Columns are always character
@@ -42,13 +36,31 @@ test_that("write_sra_table writes SRA fields", {
   attr(data, "mandatory_fields") <- character()
   data2 <- read_sra_table(fp)
   expect_identical(data2, data)
+}
+
+test_that("write_sra_table writes SRA fields", {
+  # Test write_sra_table alongside read_sra_table by ensuring they match.
+  fp <- tempfile()
+  data <- setup_sra_table()
+  write_sra_table(data, fp)
+  expect_true(file.exists(fp))
+  check_sra_table_written(data, fp)
+  # # Rownames will be sample names
+  # rownames(data) <- data$sample_name
+  # # Columns are always character
+  # data$sample_thing1 <- as.character(data$sample_thing1)
+  # # The comments and mandatory fields attributes are always present from read_sra_table
+  # attr(data, "comments") <- character()
+  # attr(data, "mandatory_fields") <- character()
+  # data2 <- read_sra_table(fp)
+  # expect_identical(data2, data)
 })
 
 test_that("write_sra_table handles overwrite options", {
   # check that overwrite is off by default and works when on
-  data <- setup_sra_table()
   fp <- tempfile()
   # Make sure overwriting is blocked by default
+  data <- setup_sra_table()
   write_sra_table(data, fp)
   expect_true(file.exists(fp))
   data2 <- read_sra_table(fp)
@@ -64,6 +76,29 @@ test_that("write_sra_table handles overwrite options", {
   expect_equal(data2$sample_name[1], "newname")
 })
 
+test_that("write_sra_table autodetermines output file path", {
+  fp <- tempfile()
+  dir.create(fp)
+  .cwd <- getwd()
+  setwd(fp)
+  data <- setup_sra_table()
+  fp <- write_sra_table(data)
+  expect_true(file.exists(fp))
+  expect_equal(fp , "./data.tsv")
+  check_sra_table_written(data, fp)
+})
+
+test_that("write_sra_table uses file suffix given", {
+  fp <- tempfile()
+  dir.create(fp)
+  .cwd <- getwd()
+  setwd(fp)
+  data <- setup_sra_table()
+  fp <- write_sra_table(data, fp_suffix = "stuff")
+  expect_true(file.exists(fp))
+  expect_equal(fp , "./stuff.tsv")
+  check_sra_table_written(data, fp)
+})
 
 
 # check_uniqueness --------------------------------------------------------


### PR DESCRIPTION
Move the automatic file path handling from individual higher-level write_ functions into write_sra_table.  Now it supports an explicit pathname or automatically determining the path based on optional arguments and the submission attribute of the input data, if present.